### PR TITLE
Stop checking if client is connected before making subscriptions

### DIFF
--- a/Assets/Scripts/Main/Web/SocketIOClientScriptable.cs
+++ b/Assets/Scripts/Main/Web/SocketIOClientScriptable.cs
@@ -169,7 +169,7 @@ public class SocketIOClientScriptable : ScriptableObject
         {
             e = new SocketIOResponseEvent(eventName);
             onReceived.Add(eventName, e);
-            if (Connection == ConnectionState.Connected) client.On(eventName, r => e.Invoke(r));
+            client.On(eventName, r => e.Invoke(r));
         }
         e.AddListener(onReception);
     }


### PR DESCRIPTION
Lors du lancement du set sur Unity, dans le SocketIOClientScriptable, on appelle `Awake` pour connecter le client, puis `OnEnable` pour s'abonner aux évènements.

Le problème est que parfois la connection du client prend plus de temps et on commence à s'abonner aux évènements avant qu'il soit connecté. En pratique avec la lib socket.io, ça ne pose pas de problème de s'abonner à un évènement avant de connecter le client, donc il faut enlever le check de connection dans le code des abonnements.